### PR TITLE
parse MATLAB script for ystep

### DIFF
--- a/app.py
+++ b/app.py
@@ -104,18 +104,22 @@ app.layout = html.Div(
 )
 def load_data(contents, filenames):
   if contents:
+    matlab_contents, _ = preprocessing.extract_matlab(contents, filenames)
+    ystep = preprocessing.extract_ystep(matlab_contents)
     datafiles = preprocessing.parse_impact(contents)
     global impact 
-    impact = Impact(datafiles, filenames)
+    impact = Impact(datafiles, filenames, ystep)
     impact_figure = callbacks.impact_figure(impact)
     scanline_toolbar = callbacks.scanline_toolbar(impact)
 
     scanline_button_divs = []
     for i, _ in enumerate(impact.scanlines):
-      scanline_button_divs.append(html.Div(id = dict(
-        type = 'scanline-graph-display',
-        index = i
-      )))
+      scanline_button_divs.append(html.Div(
+        id = dict(
+          type = 'scanline-graph-display',
+          index = i
+        )
+      ))
     
     return impact_figure, scanline_toolbar, scanline_button_divs
   return None, None, None

--- a/models/Impact.py
+++ b/models/Impact.py
@@ -3,9 +3,9 @@ import pandas as pd
 from models.ScanLine import ScanLine
 
 class Impact:
-  def __init__(self, datafiles, filenames):
+  def __init__(self, datafiles, filenames, ystep):
     self.num_scanlines = len(filenames)
-    scanlines = [ScanLine(data, filename) for data, filename in zip(datafiles, filenames)]
+    scanlines = [ScanLine(data, filename, ystep) for data, filename in zip(datafiles, filenames)]
     self.scanlines = sorted(scanlines, key = lambda x: x.ypos) 
     self.xrange = self.scanlines[0].data[:, 0][-1]
     self.reset_ypos()

--- a/models/ScanLine.py
+++ b/models/ScanLine.py
@@ -3,12 +3,11 @@ import pandas as pd
 from sklearn import linear_model
 
 class ScanLine:
-  def __init__(self, data, filename):
+  def __init__(self, data, filename, ystep = 0.02):
     try:
       self.ypos = float(filename[:8])
     except:
-      y_step = 0.02
-      self.ypos = y_step * int(filename[filename.rfind('-') + 1: filename.find('.')])
+      self.ypos = ystep * int(filename[filename.rfind('-') + 1: filename.find('.')])
 
     self.filename = filename
     self.data = data.to_numpy()
@@ -20,7 +19,6 @@ class ScanLine:
     x = self.data[:, 0].reshape(-1, 1)
     y = self.data[:, 1].reshape(-1, 1)
 
-    # linear regression
     lr = linear_model.LinearRegression()
     lr.fit(x, y.ravel())
     regression = lr.predict(x)

--- a/utils/preprocessing.py
+++ b/utils/preprocessing.py
@@ -10,8 +10,21 @@ def parse_impact(contents):
     datafiles.append(pd.read_excel(io.BytesIO(decoded), sheet_name = 'DATA', header = None, nrows = 6000, usecols = 'E:F', keep_default_na = False))
   return datafiles
 
-def extract_ypos(file):
-  # get the file
-  # find the ypos from the file
-  # get the number that follows the ypos
-  return
+def extract_ystep(matlab_contents):
+  if matlab_contents:
+    _, content_string = matlab_contents.split(',')
+    decoded = base64.b64decode(content_string)
+    matlab_file = io.BytesIO(decoded)
+    for line in matlab_file:
+      line = line.decode('utf-8')
+      if line.startswith('ystep ='):
+        return float(line[line.find('=') + 2 : line.find(';')])
+  return 0.02
+
+def extract_matlab(contents, filenames):
+  matlab_contents, matlab_filename = None, None
+  for i, filename in enumerate(filenames):
+    if filename.endswith('.m'):
+      matlab_filename = filenames.pop(i)
+      matlab_contents = contents.pop(i)
+  return matlab_contents, matlab_filename


### PR DESCRIPTION
Allows the user to select a MATLAB script along with the Excel files to extract the spacing between scans in the y-direction. To use, upload the MATLAB file (usually <code>plot.m</code> or <code>SurfacePlot.m</code>) along with the Excel files by using CMD + Click after selecting all of the Excel files Default value of 0.02mm.